### PR TITLE
feat(data): DTO+mappers, datasources y repos impl (stub)

### DIFF
--- a/app/lib/data/datasources/mqtt_realtime_ds.dart
+++ b/app/lib/data/datasources/mqtt_realtime_ds.dart
@@ -1,0 +1,7 @@
+class MqttRealtimeDataSource {
+  // TODO: implementar suscripción a tópicos MQTT cuando se defina el broker.
+  Stream<String> intrusionEvents(String unitId) async* {
+    // Ejemplo de stream simulado
+    // yield 'intrusion:$unitId';
+  }
+}

--- a/app/lib/data/datasources/units_local_ds.dart
+++ b/app/lib/data/datasources/units_local_ds.dart
@@ -1,0 +1,7 @@
+class UnitsLocalDataSource {
+  final List<Map<String, dynamic>> _cache = const [];
+
+  Future<List<Map<String, dynamic>>> listUnitsCached() async {
+    return _cache;
+  }
+}

--- a/app/lib/data/datasources/units_remote_ds.dart
+++ b/app/lib/data/datasources/units_remote_ds.dart
@@ -1,0 +1,10 @@
+class UnitsRemoteDataSource {
+  Future<List<Map<String, dynamic>>> listUnits() async {
+    // TODO: reemplazar por llamada HTTP real (Dio) cuando esté definido.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    return [
+      {'id': 'U-101', 'name': 'Unidad 101'},
+      {'id': 'U-102', 'name': 'Unidad 102'},
+    ];
+  }
+}

--- a/app/lib/data/models/invoice_dto.dart
+++ b/app/lib/data/models/invoice_dto.dart
@@ -1,0 +1,10 @@
+class InvoiceDto {
+  final String id;
+  final double amount;
+  const InvoiceDto({required this.id, required this.amount});
+
+  factory InvoiceDto.fromJson(Map<String, dynamic> j) =>
+      InvoiceDto(id: j['id'] as String, amount: (j['amount'] as num).toDouble());
+
+  Map<String, dynamic> toJson() => {'id': id, 'amount': amount};
+}

--- a/app/lib/data/models/mappers.dart
+++ b/app/lib/data/models/mappers.dart
@@ -1,0 +1,10 @@
+// NOTA: cuando la capa Domain esté lista, importa las entidades reales y ajusta.
+// import '../../domain/entities/unit.dart' show Unit;
+// Unit toEntity(UnitDto dto) => Unit(dto.id);
+
+// Por ahora devolvemos un Map simple para no romper el build si Domain aún no está.
+import 'unit_dto.dart';
+import 'invoice_dto.dart';
+
+Map<String, dynamic> mapUnit(UnitDto dto) => dto.toJson();
+Map<String, dynamic> mapInvoice(InvoiceDto dto) => dto.toJson();

--- a/app/lib/data/models/unit_dto.dart
+++ b/app/lib/data/models/unit_dto.dart
@@ -1,0 +1,10 @@
+class UnitDto {
+  final String id;
+  final String name;
+  const UnitDto({required this.id, required this.name});
+
+  factory UnitDto.fromJson(Map<String, dynamic> j) =>
+      UnitDto(id: j['id'] as String, name: j['name'] as String);
+
+  Map<String, dynamic> toJson() => {'id': id, 'name': name};
+}

--- a/app/lib/data/repositories_impl/auth_repository_impl.dart
+++ b/app/lib/data/repositories_impl/auth_repository_impl.dart
@@ -1,0 +1,9 @@
+// import '../../domain/repositories/auth_repo.dart';
+
+class AuthRepositoryImpl /* implements IAuthRepository */ {
+  Future<bool> login(String user, String pass) async {
+    // TODO: llamada HTTP real
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    return user.isNotEmpty && pass.isNotEmpty;
+  }
+}

--- a/app/lib/data/repositories_impl/billing_repository_impl.dart
+++ b/app/lib/data/repositories_impl/billing_repository_impl.dart
@@ -1,0 +1,10 @@
+// import '../../domain/repositories/billing_repo.dart';
+import '../models/invoice_dto.dart';
+
+class BillingRepositoryImpl /* implements IBillingRepository */ {
+  Future<List<InvoiceDto>> listInvoices() async {
+    // TODO: HTTP real
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    return [InvoiceDto(id: 'INV-001', amount: 199.0)];
+  }
+}

--- a/app/lib/data/repositories_impl/units_repository_impl.dart
+++ b/app/lib/data/repositories_impl/units_repository_impl.dart
@@ -1,0 +1,22 @@
+// Cuando Domain esté disponible, descomenta la import y el implements:
+// import '../../domain/repositories/units_repo.dart';
+
+import '../datasources/units_remote_ds.dart';
+import '../datasources/units_local_ds.dart';
+import '../models/unit_dto.dart';
+
+class UnitsRepositoryImpl /* implements IUnitsRepository */ {
+  final UnitsRemoteDataSource remote;
+  final UnitsLocalDataSource local;
+
+  UnitsRepositoryImpl({required this.remote, required this.local});
+
+  Future<List<UnitDto>> listUnits() async {
+    final raw = await remote.listUnits();
+    return raw.map((j) => UnitDto.fromJson(j)).toList();
+  }
+
+  // Cuando exista IUnitsRepository en Domain, ajusta la firma:
+  // @override
+  // Future<List<Unit>> listUnits() async { ... mapear a entidad ... }
+}


### PR DESCRIPTION
- Crea capa Data: models (DTO), mappers, datasources (remote/local/realtime).
- Implementa UnitsRepositoryImpl (stub) y repos básicos de auth/billing.
- Aún sin depender de Domain para evitar errores; listo para conectar cuando esté mergeado.
- Verificación: dart format, flutter analyze OK.
